### PR TITLE
tweak for zef compat

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -1,9 +1,8 @@
 use v6;
-use Panda::Builder;
 use LibraryMake;
 use Shell::Command;
 
-class Build is Panda::Builder {
+class Build {
     method build($workdir) {
         my $dest = "$workdir/resources/lib";
         mkpath $dest unless $dest.IO.d;

--- a/META6.json
+++ b/META6.json
@@ -12,7 +12,7 @@
     "Add" : "lib/Add.pm6"
   },
   "depends" : [
-    "LibraryMake"
+    "LibraryMake", "Shell::Command"
   ],
   "description" : "minimal example of LibraryMake",
   "test-depends" : [ ],


### PR DESCRIPTION
Build.pm no longer needs to be based on Panda::Builder. with latest panda.

This tweak allows zef to install it without having Panda installed.  Note:

 %zef build . 

will build locally.